### PR TITLE
Feature/sc 11338/update hubspot auth to legacy backend

### DIFF
--- a/hubspot-mailer.gemspec
+++ b/hubspot-mailer.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
   s.name        = "hubspot-mailer".freeze
-  s.version     = "0.0.3"
+  s.version     = "0.0.4"
   s.licenses    = ['MIT']
-  s.date        = "2021-06-06".freeze
+  s.date        = "2022-10-19".freeze
   s.description = "Create beautiful transactional emails right within HubSpot using the email editor with all the benefits of smart content, personalization and templates - just like regular HubSpot emails. Create beautiful transactional emails right within HubSpot using the email editor with all the benefits of smart content, personalization and templates - just like regular HubSpot emails. Create beautiful transactional emails right within HubSpot using the email editor with all the benefits of smart content, personalization and templates - just like regular HubSpot emails.".freeze
   s.summary     = "HubSpot Single Send API SDK for use with Ruby on Rails".freeze
   s.authors     = ["heaven".freeze]
@@ -22,16 +22,16 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0')
-      s.add_runtime_dependency(%q<hubspot-ruby>.freeze, ["~> 0.4"])
+      s.add_runtime_dependency(%q<httparty>.freeze, ["~> 0.20.0"])
       s.add_runtime_dependency(%q<actionmailer>.freeze, ["< 6.1"])
       s.add_development_dependency(%q<bundler>.freeze, ["~> 1.0"])
     else
-      s.add_dependency(%q<hubspot-ruby>.freeze, ["~> 0.4"])
+      s.add_dependency(%q<httparty>.freeze, ["~> 0.20.0"])
       s.add_dependency(%q<actionmailer>.freeze, ["< 6.1"])
       s.add_dependency(%q<bundler>.freeze, ["~> 1.0"])
     end
   else
-    s.add_dependency(%q<hubspot-ruby>.freeze, ["~> 0.4"])
+    s.add_dependency(%q<httparty>.freeze, ["~> 0.20.0"])
     s.add_dependency(%q<actionmailer>.freeze, ["~> 5.1"])
     s.add_dependency(%q<bundler>.freeze, ["~> 1.0"])
   end

--- a/hubspot-mailer.gemspec
+++ b/hubspot-mailer.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
   s.name        = "hubspot-mailer".freeze
-  s.version     = "0.0.2"
+  s.version     = "0.0.3"
   s.licenses    = ['MIT']
-  s.date        = "2018-12-09".freeze
+  s.date        = "2021-06-06".freeze
   s.description = "Create beautiful transactional emails right within HubSpot using the email editor with all the benefits of smart content, personalization and templates - just like regular HubSpot emails. Create beautiful transactional emails right within HubSpot using the email editor with all the benefits of smart content, personalization and templates - just like regular HubSpot emails. Create beautiful transactional emails right within HubSpot using the email editor with all the benefits of smart content, personalization and templates - just like regular HubSpot emails.".freeze
   s.summary     = "HubSpot Single Send API SDK for use with Ruby on Rails".freeze
   s.authors     = ["heaven".freeze]

--- a/lib/hubspot-mailer.rb
+++ b/lib/hubspot-mailer.rb
@@ -1,5 +1,5 @@
+require 'httparty'
 require 'action_mailer'
-require 'hubspot-ruby'
 require 'hubspot/mailer/delivery'
 require 'hubspot/mailer/exceptions'
 require 'hubspot/mailer/hubspot_preview_interceptor'

--- a/lib/hubspot/mailer.rb
+++ b/lib/hubspot/mailer.rb
@@ -68,10 +68,14 @@ module Hubspot
           message: { to: mail.to.first }
         }
 
-        data[:message][:from]   = mail.from.first if mail.from.present?
         data[:message][:cc]     = mail.cc         if mail.cc.present?
         data[:message][:bcc]    = mail.bcc        if mail.bcc.present?
         data[:message][:sendId] = mail.send_id    if mail.send_id.present?
+
+        if mail.from.present?
+          raise SenderAddressError.new, "Can't handle multiple from addresses" if mail.from.count > 1
+          data[:message][:from] = mail.header[:from].value
+        end
 
         if mail.reply_to.present?
           if mail.reply_to.size > 1


### PR DESCRIPTION
Update auth method to use a bearer token which is provided to the mailer class.
Remove dependency on hubspot-ruby, implement http post to hubspot api directly.